### PR TITLE
バグの修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'debug'
 
 DRINKS = [
   { name: 'コーヒー', price: 300 },

--- a/cafe.rb
+++ b/cafe.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'debug'
 
 DRINKS = [
   { name: 'コーヒー', price: '300' },
@@ -19,7 +20,7 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end

--- a/cafe.rb
+++ b/cafe.rb
@@ -30,5 +30,6 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = DRINKS[order1][:price] + FOODS[order2][:price]
+
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -2,17 +2,17 @@
 require 'debug'
 
 DRINKS = [
-  { name: 'コーヒー', price: '300' },
-  { name: 'カフェラテ', price: '400' },
-  { name: 'チャイ', price: '460' },
-  { name: 'エスプレッソ', price: '340' },
-  { name: '緑茶', price: '450' }
+  { name: 'コーヒー', price: 300 },
+  { name: 'カフェラテ', price: 400 },
+  { name: 'チャイ', price: 460 },
+  { name: 'エスプレッソ', price: 340 },
+  { name: '緑茶', price: 450 }
 ].freeze
 
 FOODS = [
-  { name: 'チーズケーキ', price: '470' },
-  { name: 'アップルパイ', price: '520' },
-  { name: 'ホットサンド', price: '410' }
+  { name: 'チーズケーキ', price: 470 },
+  { name: 'アップルパイ', price: 520 },
+  { name: 'ホットサンド', price: 410 }
 ].freeze
 
 def take_order(menus)


### PR DESCRIPTION
下記のバグを修正しました。

- 頼んだつもりのメニューが選択できない
- 最後の番号のメニューを選択するとエラーとなる
- お会計額が正しくない
  - 違う番号のドリンク、フードを注文したとき、お会計が正しくない。


問題と思われますが、対応していない内容は次のとおりです。

- 想定していない入力への対応。
    - 例: メニューに存在しない番号、文字列の入力、空行での入力
    - 特に、空行を入力した場合はエラーとならず、最後のメニューが選択されます。
    
    
    
